### PR TITLE
fix(runtime): forward JSX key arg to controls that declare a key property

### DIFF
--- a/.changeset/fix-key-prop-forwarding.md
+++ b/.changeset/fix-key-prop-forwarding.md
@@ -1,0 +1,9 @@
+---
+"@ui5-community/jsx-runtime": patch
+---
+
+Fix `key` prop being silently dropped for controls that declare it as a property (e.g. `sap.ui.core.CustomData`).
+
+Babel's automatic JSX transform always extracts `key` from the element's attributes and passes it as the third argument to `jsx(type, props, key)` — it is never present in the `props` object. The runtime now detects this case and forwards the value to the control's `key` property when the control metadata declares one. For controls without a `key` property the behaviour is unchanged.
+
+Fixes #3.

--- a/packages/jsx-runtime-showcase/webapp/controller/Explorer.controller.ts
+++ b/packages/jsx-runtime-showcase/webapp/controller/Explorer.controller.ts
@@ -112,7 +112,8 @@ export default class Explorer extends Controller {
 		{ key: "explore.g.advanced", title: "Advanced", icon: "sap-icon://sys-help", children: [
 			{ key: "explore.controller-as-file", title: "Controller as separate file", icon: "sap-icon://source-code", route: "exploreSample", arg: "controller-as-file" },
 			{ key: "explore.structural",      title: "Structural <For>, <If>",    icon: "sap-icon://tree",           route: "exploreSample", arg: "structural" },
-			{ key: "explore.type-coercion", title: "Property type coercion", icon: "sap-icon://alert",         route: "exploreSample", arg: "type-coercion" }
+			{ key: "explore.type-coercion", title: "Property type coercion", icon: "sap-icon://alert",         route: "exploreSample", arg: "type-coercion" },
+			{ key: "explore.custom-data-key", title: "CustomData & the key prop", icon: "sap-icon://key-user-settings", route: "exploreSample", arg: "custom-data-key" }
 		]},
 		{ key: "explore.g.plugins", title: "Plugins / Extend", icon: "sap-icon://puzzle", children: [
 			{ key: "explore.switch-plugin", title: "Plugin <Switch>", icon: "sap-icon://switch-classes", route: "exploreSample", arg: "switch-plugin" }

--- a/packages/jsx-runtime-showcase/webapp/docs/samples/custom-data-key.md
+++ b/packages/jsx-runtime-showcase/webapp/docs/samples/custom-data-key.md
@@ -1,0 +1,71 @@
+# CustomData & the reserved `key` prop
+
+`sap.ui.core.CustomData` lets you attach arbitrary key/value pairs to any UI5 control.
+When `writeToDom` is `true`, UI5 renders those pairs directly as `data-<key>` HTML
+attributes — useful for CSS selectors, automated tests, and accessibility tooling.
+
+The natural JSX for this looks exactly right:
+
+```tsx
+<Button text="Inspect me">
+  <customData>
+    <CustomData key="product-id" value="4711" writeToDom={true} />
+  </customData>
+</Button>
+```
+
+Or, using the aggregation-as-prop shorthand:
+
+```tsx
+<Button
+  text="Inspect me"
+  customData={<CustomData key="product-id" value="4711" writeToDom={true} />}
+/>
+```
+
+## Why `key` was silently dropped before the fix
+
+Babel's *automatic* JSX transform (enabled with `importSource`) **always** extracts the
+`key` attribute from an element and passes it as the third argument to the runtime's
+`jsx()` function — it is **never** present inside the `props` object:
+
+```ts
+// what Babel emits for <CustomData key="product-id" value="4711" />
+jsx(CustomData, { value: "4711" }, "product-id");
+//                                  ^^^^^^^^^^^^ third arg, NOT in props
+```
+
+React uses this third argument for reconciliation ("which list item am I?"). It has
+nothing to do with UI5 properties. So the naive JSX runtime just ignored it — and
+`CustomData.setKey()` was never called, leaving the key empty and producing no DOM
+attribute.
+
+This was [GitHub issue #3](https://github.com/ui5-community/jsx-runtime/issues/3).
+
+## The fix (PR #4)
+
+The runtime now inspects the control's UI5 metadata after processing the normal `props`:
+
+```ts
+if (_key !== undefined && metadata.hasProperty("key")) {
+    propEntries.push(["key", _key]);
+}
+```
+
+This re-injects the Babel-extracted `key` argument into the settings object, but *only*
+for controls that actually declare a `key` property in their metadata.
+`sap.ui.core.CustomData` is the canonical example; `sap.m.Button` (which has no `key`
+property) is completely unaffected — the extra third argument is still silently ignored
+for it.
+
+## Live sample
+
+The sample in this page attaches `<CustomData key="product-id" value="4711"
+writeToDom={true} />` to a button using the aggregation-as-prop syntax. After the button
+renders, `onAfterRendering()` reads `dom.getAttribute("data-product-id")` and displays
+the value — proving the key reached the control and the DOM attribute was written.
+
+Concept reference: [runtime anatomy](#/learn/runtime-anatomy).
+
+See also: [prop-typing](#/explore/prop-typing) — per-control TypeScript prop types that
+catch wrong property names at compile time.

--- a/packages/jsx-runtime-showcase/webapp/view/ExploreSample.tsx
+++ b/packages/jsx-runtime-showcase/webapp/view/ExploreSample.tsx
@@ -148,6 +148,12 @@ const REGISTRY: Record<string, {
 		icon: "sap-icon://grid",
 		viewName: "ui5.community.jsx.showcase.view.showcases.TableGrid",
 		sourcePath: "view/showcases/TableGrid.tsx"
+	},
+	"custom-data-key": {
+		title: "CustomData & the key prop",
+		icon: "sap-icon://key-user-settings",
+		viewName: "ui5.community.jsx.showcase.view.showcases.CustomDataKey",
+		sourcePath: "view/showcases/CustomDataKey.tsx"
 	}
 };
 

--- a/packages/jsx-runtime-showcase/webapp/view/showcases/CustomDataKey.tsx
+++ b/packages/jsx-runtime-showcase/webapp/view/showcases/CustomDataKey.tsx
@@ -1,0 +1,94 @@
+import View from "sap/ui/core/mvc/View";
+import type Control from "sap/ui/core/Control";
+import VBox from "sap/m/VBox";
+import Button from "sap/m/Button";
+import Title from "sap/m/Title";
+import Text from "sap/m/Text";
+import MessageStrip from "sap/m/MessageStrip";
+import CustomData from "sap/ui/core/CustomData";
+
+/**
+ * # The reserved `key` prop and `sap.ui.core.CustomData`
+ *
+ * Babel's automatic JSX transform **always** extracts `key` from an
+ * element's attribute list and passes it as the *third* argument to
+ * `jsx(type, props, key)` — it never appears inside `props`. This is
+ * how React tracks reconciliation keys, but it creates a problem for
+ * `sap.ui.core.CustomData`, which declares `key` as a genuine UI5
+ * *property*: the value was silently discarded before it could reach
+ * `CustomData.setKey()`, so `writeToDom={true}` never produced the
+ * expected `data-<key>` attribute in the DOM (GitHub issue #3).
+ *
+ * The runtime fix (PR #4) detects the reserved `key` argument and
+ * re-injects it as a property **only** for controls whose UI5 metadata
+ * declares a `key` property (`metadata.hasProperty("key")`). Controls
+ * like `Button` that have no such property are unaffected — the third
+ * argument is still silently ignored for them.
+ *
+ * This sample demonstrates the fixed behaviour end-to-end: the button
+ * below carries a `CustomData` whose `key` was written using a plain
+ * JSX `key="product-id"` attribute; after rendering the readout shows
+ * the DOM attribute that proves the value reached the control.
+ *
+ * @namespace ui5.community.jsx.showcase.view.showcases
+ */
+export default class CustomDataKey extends View {
+	private _button!: Button;
+	private _readout!: Text;
+
+	getAutoPrefixId(): boolean {
+		return true;
+	}
+
+	createContent(): Control {
+		this._readout = <Text text="(renders after the button paints)" /> as Text;
+
+		this._button = (
+			<Button
+				text="Inspect me in the DOM"
+				customData={
+					// `key` is the reserved JSX prop — Babel passes it as the
+					// 3rd arg to jsx(). The fixed runtime forwards it to
+					// CustomData.setKey() because CustomData.metadata declares
+					// a `key` property.
+					<CustomData key="product-id" value="4711" writeToDom={true} />
+				}
+			/>
+		) as Button;
+
+		return (
+			<VBox class="sapUiSmallMargin">
+				<MessageStrip
+					text="Babel extracts `key` from JSX attributes and passes it as the 3rd argument to jsx() — never inside props. The runtime now forwards it to controls whose metadata declares a key property."
+					type="Information"
+					showIcon={true}
+					class="sapUiSmallMarginBottom"
+				/>
+
+				<Title text="Button with CustomData key=&quot;product-id&quot;" level="H4" />
+				<Text
+					text='<CustomData key="product-id" value="4711" writeToDom={true} /> — the key prop reaches setKey() and produces data-product-id in the DOM.'
+					class="sapUiTinyMarginBottom"
+				/>
+				{this._button}
+
+				<Title text="DOM attribute readout (after render)" level="H4" class="sapUiSmallMarginTop" />
+				{this._readout}
+			</VBox>
+		);
+	}
+
+	onAfterRendering(): void {
+		const dom = this._button.getDomRef();
+		const attr = dom?.getAttribute("data-product-id");
+		if (attr !== null && attr !== undefined) {
+			this._readout.setText(
+				`DOM attribute: data-product-id="${attr}"   ·   button.data("product-id") = ${String(this._button.data("product-id"))}`
+			);
+		} else {
+			this._readout.setText(
+				"No data-product-id attribute found — the key prop was not forwarded (pre-fix behaviour)."
+			);
+		}
+	}
+}

--- a/packages/jsx-runtime/src/runtime/runtime.ts
+++ b/packages/jsx-runtime/src/runtime/runtime.ts
@@ -193,9 +193,10 @@ function makeHandler(handlerName: string): (this: Element, event: Event) => void
  * the rest (binding extraction, aggregation wiring, applying defaults) under
  * the default control-instance renderer.
  *
- * Babel may pass an extra `key` argument for keyed lists; UI5 doesn't have a
- * concept of React keys, so we accept it for signature compatibility and
- * ignore it.
+ * Babel may pass an extra `key` argument for keyed lists. When the target
+ * control declares a property named `key` (e.g. `sap.ui.core.CustomData`),
+ * the value is forwarded to that property. Otherwise it is ignored — UI5 has
+ * no concept of React-style list reconciliation keys.
  *
  * @example
  * // Consumers never call jsx() directly; Babel's automatic runtime
@@ -276,6 +277,14 @@ export function jsx<T extends ManagedObject>(
 	// by the applier loop after construction. Cache it so hot views
 	// pay the allocation once per element rather than twice.
 	const propEntries = Object.entries(allProps);
+	// Babel's automatic JSX transform always extracts the `key` prop from the
+	// element's attributes and passes it as the third argument to `jsx()`, never
+	// inside the props object. For controls that own a real `key` property (e.g.
+	// `sap.ui.core.CustomData`), inject it back into the entries so it travels
+	// through the normal intrinsic + applier pipeline and lands in settings.
+	if (_key !== undefined && metadata.hasProperty("key")) {
+		propEntries.push(["key", _key]);
+	}
 
 	for (const [key, value] of propEntries) {
 		if (key === "children") {

--- a/packages/jsx-runtime/test/qunit/runtime/jsx.qunit.ts
+++ b/packages/jsx-runtime/test/qunit/runtime/jsx.qunit.ts
@@ -9,6 +9,7 @@ import { jsx, jsxs } from "ui5/community/jsx/runtime/jsx-runtime";
 import Button from "sap/m/Button";
 import VBox from "sap/m/VBox";
 import Text from "sap/m/Text";
+import CustomData from "sap/ui/core/CustomData";
 
 QUnit.module("runtime/jsx");
 
@@ -46,4 +47,22 @@ QUnit.test("string type throws when no htmlIntrinsic is registered", (assert) =>
 		/htmlIntrinsic|renderer/i,
 		"clear error naming the missing HTML intrinsic"
 	);
+});
+
+// Babel's automatic JSX transform extracts `key` from the element's attributes
+// and passes it as the third argument to jsx(). Controls that declare a real
+// `key` property (like sap.ui.core.CustomData) must receive that value.
+QUnit.test("jsx() forwards the third 'key' arg to a control that has a key property", (assert) => {
+	const cd = jsx(CustomData, { value: "123test" }, "testkey") as CustomData;
+	assert.strictEqual(cd.getKey(), "testkey", "key property set from third argument");
+	cd.destroy();
+});
+
+QUnit.test("jsx() ignores the third 'key' arg for controls without a key property", (assert) => {
+	// Button has no `key` property — the third arg must be silently dropped.
+	assert.ok(() => {
+		const b = jsx(Button, { text: "ok" }, "some-key") as Button;
+		b.destroy();
+		return true;
+	}, "no throw when key arg passed to a control without a key property");
 });


### PR DESCRIPTION
## Summary

Fixes #3.

Babel's automatic JSX transform always extracts the `key` prop from element attributes and passes it as the **third argument** to `jsx(type, props, key)` — it is never inside the `props` object. Controls like `sap.ui.core.CustomData` declare a real `key` property (unrelated to React's reconciliation concept), so `<CustomData key="testkey" .../>` compiled to `_jsx(CustomData, {...}, "testkey")` and the key was silently dropped, producing the empty-key warning from UI5.

## Changes

- **[`runtime.ts`](packages/jsx-runtime/src/runtime/runtime.ts):** After building `propEntries`, inject `["key", _key]` when `_key` is defined and the control metadata declares a `key` property. The entry then travels through the normal intrinsic + applier pipeline (including `propertyTypeIntrinsic` validation) exactly like any other prop. For all controls without a `key` property the behaviour is unchanged.
- **[`jsx.qunit.ts`](packages/jsx-runtime/test/qunit/runtime/jsx.qunit.ts):** Two new tests — one verifying `CustomData.key` is set from the third arg, one confirming controls without a `key` property don't throw.
- **`.changeset/fix-key-prop-forwarding.md`:** Patch-level changeset.
- **Showcase — Explore → Advanced → "CustomData & the key prop":** Live sample ([`CustomDataKey.tsx`](packages/jsx-runtime-showcase/webapp/view/showcases/CustomDataKey.tsx)) that attaches `<CustomData key="product-id" value="4711" writeToDom={true} />` to a button and reads the resulting `data-product-id` attribute back in `onAfterRendering()` — giving an in-browser proof the fix is working end-to-end. Also removes the motivation for the `new NavigationListItem({ key: "…" })` workaround noted in `Explorer.controller.ts`.

## Test plan

- [ ] `pnpm --filter @ui5-community/jsx-runtime ts-typecheck` passes
- [ ] `pnpm --filter @ui5-community/jsx-runtime-showcase ts-typecheck` passes
- [ ] `pnpm --filter @ui5-community/jsx-runtime test-runner` — new tests green, no regressions
- [ ] Showcase: navigate to **Explore → Advanced → CustomData & the key prop** (`#/explore/custom-data-key`); readout shows `DOM attribute: data-product-id="4711"` and browser devtools confirm the attribute on the button's root element