### PR TITLE
feat(runtime): log JSX view-construction errors via sap/base/Log

### DIFF
--- a/.changeset/log-view-errors.md
+++ b/.changeset/log-view-errors.md
@@ -1,0 +1,19 @@
+---
+"@ui5-community/jsx-runtime": patch
+---
+
+JSX view-construction errors are now logged via `sap/base/Log` in addition
+to propagating. Previously, when `createContent()` threw (sync or async),
+the error was only visible as a rejected Promise and, in the showcase, as
+a text message rendered into the DOM. It was never written to the UI5 Log,
+making it invisible to log-scraping tooling and `sap-ui-log-level` debugging.
+
+`installViewScopeBridge` now wraps the `createContent()` call with a
+try/catch (sync) and a `.catch` on the returned Promise (async). On failure
+it calls `Log.error` with the full error message, the stack trace, and the
+component id `"ui5.community.jsx.runtime"`, then re-throws / re-rejects so
+existing propagation behaviour is unchanged.
+
+The showcase's `ExploreSample` view also adds `Log.error` calls in both its
+demo-view and docs-load catch handlers so the exact user-facing message
+appears in the log as well.

--- a/packages/jsx-runtime-showcase/webapp/view/ExploreSample.tsx
+++ b/packages/jsx-runtime-showcase/webapp/view/ExploreSample.tsx
@@ -10,6 +10,7 @@ import HBox from "sap/m/HBox";
 import Title from "sap/m/Title";
 import Text from "sap/m/Text";
 import MessageStrip from "sap/m/MessageStrip";
+import Log from "sap/base/Log";
 import * as Prism from "prismjs";
 
 import CodeBlock from "../control/CodeBlock";
@@ -324,6 +325,11 @@ export default class ExploreSample extends View {
 			})
 			.catch((error: unknown) => {
 				if (this.currentSampleId !== sampleId) return;
+				Log.error(
+					`Could not load docs/samples/${sampleId}.md: ${String(error)}`,
+					error instanceof Error ? (error.stack ?? "") : "",
+					"ui5.community.jsx.showcase.view.ExploreSample"
+				);
 				this.description.setContent(
 					`<div class="jsx-showcase-explore-description">` +
 					`<p><i>Could not load docs/samples/${escapeHtml(sampleId)}.md: ${escapeHtml(String(error))}</i></p>` +
@@ -350,6 +356,11 @@ export default class ExploreSample extends View {
 			this.demoSlot.removeAllItems();
 			this.demoSlot.addItem(demoView);
 		}).catch((error: unknown) => {
+			Log.error(
+				`Failed to load ${reg.viewName}: ${String(error)}`,
+				error instanceof Error ? (error.stack ?? "") : "",
+				"ui5.community.jsx.showcase.view.ExploreSample"
+			);
 			this.demoSlot.removeAllItems();
 			this.demoSlot.addItem(new Text({
 				text: `Failed to load ${reg.viewName}: ${String(error)}`

--- a/packages/jsx-runtime/src/runtime/installViewScopeBridge.ts
+++ b/packages/jsx-runtime/src/runtime/installViewScopeBridge.ts
@@ -1,5 +1,6 @@
 import View from "sap/ui/core/mvc/View";
 import type Control from "sap/ui/core/Control";
+import Log from "sap/base/Log";
 import { withScope } from "./scope";
 
 /**
@@ -15,36 +16,44 @@ import { withScope } from "./scope";
  *
  * The clean way to expose that context is to wrap the
  * subclass's `createContent()` in a `withScope({ view: this },
- * …)`. Doing that at every JSX-view call site is noise every
- * consumer would repeat. Instead this module installs a
- * one-time prototype patch on `sap.ui.core.mvc.View.prototype.createContent`
- * that transparently opens the scope for the duration of the
- * subclass's own `createContent()` call.
+ * …)`. This module installs a one-time prototype patch on
+ * `View.prototype.onControllerConnected` that does exactly that:
+ * before delegating to the original `onControllerConnected`, it
+ * installs a per-instance wrapper on `this.createContent` that
+ * opens the scope and catches errors, then cleans up via `finally`.
  *
- * ## Why patch the base prototype
+ * ## Why patch `onControllerConnected`, not `createContent`
  *
- * `sap.ui.core.mvc.View`'s design invites subclasses to override
- * `createContent()`. XMLView, JSONView, TypedView, JSView all
- * do exactly that, none of them calls `super.createContent()`,
- * and the base method is a no-op that returns `null`. Patching
- * the *base* prototype's `createContent` catches every subclass
- * override transparently: when a JSX view's own
- * `createContent()` runs, it does so with `this === theView`
- * *and* under an active JSX scope that carries the view. XMLView
- * / JSONView still work, they don't call `jsx()`, so the added
- * scope is a no-op for them.
+ * UI5's `onControllerConnected` calls `this.createContent(e)`,
+ * which dynamically dispatches to the **subclass** prototype
+ * (e.g. `MyJsxView.prototype.createContent`). Patching
+ * `View.prototype.createContent` only intercepts code that
+ * explicitly calls `super.createContent()` — no View subclass
+ * ever does that (the base method is a no-op returning `null`).
+ *
+ * By patching `onControllerConnected` instead, we install a
+ * per-instance own-property on `this.createContent` *before*
+ * the original `onControllerConnected` body runs. Own-properties
+ * shadow prototype properties, so `this.createContent(...)` in
+ * `runWithPreprocessors` routes through our wrapper regardless
+ * of which subclass is in play.
+ *
+ * XMLView / JSONView / TypedView override `createContent()` and
+ * don't call `jsx()`, so the added `withScope` is a no-op for
+ * them. Error-logging is equally transparent — only JSX views
+ * are likely to throw novel errors, and the log entry will
+ * clearly identify the view by id.
  *
  * ## The idempotence guard
  *
  * `installed` prevents double-wrapping if this module is loaded
  * twice (e.g. via two different resource-root mappings, or from
- * a test harness that reloads the runtime). Double-wrapping
- * wouldn't be catastrophic (the inner `withScope` merges its
- * partial on top of the parent scope), but it would obscure the
- * ambient-state chain and every retry would pay a stack frame.
+ * a test harness that reloads the runtime).
  *
  * @namespace ui5.community.jsx.runtime.jsx-runtime
  */
+const COMPONENT = "ui5.community.jsx.runtime";
+
 let installed = false;
 
 /**
@@ -56,24 +65,64 @@ let installed = false;
 export function installViewScopeBridge(): void {
 	if (installed) return;
 	installed = true;
-	const original = View.prototype.createContent as (
-		this: View
-	) => Control | Control[] | Promise<Control | Control[]>;
-	View.prototype.createContent = function patchedCreateContent(
-		this: View
-	): Control | Control[] | Promise<Control | Control[]> {
-		// The `view: this` slot on `Scope` is what `jsx()` reads
-		// when deciding whether to auto-prefix a child control's
-		// `id`. The scope is popped on the callback's synchronous
-		// return; async `createContent()` overrides (those that
-		// return a Promise) also get the view in scope only for
-		// the synchronous body preceding the first `await`, the
-		// hot path for auto-prefixing (control construction inside
-		// a JSX expression before an `await`) is fully covered.
-		//
-		// XMLView / JSONView / TypedView override `createContent()`
-		// without ever calling `jsx()`, so the ambient scope is
-		// unused for them. Zero cost.
-		return withScope({ view: this }, () => original.apply(this, []));
-	} as typeof View.prototype.createContent;
+
+	// `onControllerConnected` is an internal UI5 method not exposed in the
+	// public TypeScript typings — use `any` casts to access/patch it.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const viewProto = View.prototype as any;
+	type CreateContentFn = (this: View) => Control | Control[] | Promise<Control | Control[]>;
+	type OnControllerConnectedFn = (this: View, controller: unknown, settings?: unknown) => unknown;
+
+	const originalOnControllerConnected = viewProto.onControllerConnected as OnControllerConnectedFn;
+
+	viewProto.onControllerConnected = function patchedOnControllerConnected(
+		this: View,
+		controller: unknown,
+		settings?: unknown
+	): unknown {
+		// Retrieve the subclass's (or base's) createContent *now*, before we
+		// shadow it on the instance.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const subclassCreateContent = (this as any).createContent as CreateContentFn;
+
+		const viewId = this.getId();
+
+		const logAndRethrow = (error: unknown): never => {
+			Log.error(
+				`createContent() failed for view '${viewId}': ${String(error)}`,
+				error instanceof Error ? (error.stack ?? "") : "",
+				COMPONENT
+			);
+			throw error;
+		};
+
+		// Install the per-instance wrapper that the `onControllerConnected`
+		// body will call via `this.createContent(...)`.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(this as any).createContent = function wrappedCreateContent(
+			this: View
+		): Control | Control[] | Promise<Control | Control[]> {
+			return withScope({ view: this }, () => {
+				let result: Control | Control[] | Promise<Control | Control[]>;
+				try {
+					result = subclassCreateContent.call(this);
+				} catch (error) {
+					return logAndRethrow(error);
+				}
+				if (result instanceof Promise) {
+					return result.catch(logAndRethrow);
+				}
+				return result;
+			});
+		};
+
+		try {
+			return originalOnControllerConnected.call(this, controller, settings);
+		} finally {
+			// Always clean up the instance shadow so the prototype chain is
+			// restored for any subsequent calls on this view instance.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			delete (this as any).createContent;
+		}
+	};
 }

--- a/packages/jsx-runtime/test/qunit/runtime/forwarded-aggregation.qunit.ts
+++ b/packages/jsx-runtime/test/qunit/runtime/forwarded-aggregation.qunit.ts
@@ -1,0 +1,50 @@
+/**
+ * QUnit regression tests for forwarded default aggregations (issue #9).
+ *
+ * Controls like `sap.m.Menu` declare their default aggregation (`items`)
+ * with **aggregation forwarding**: the real target is an internal
+ * `MenuWrapper` created in `Menu.prototype.init()` and resolved by id at
+ * add-time. Passing `items` in the single-shot `new Menu({ items })` call
+ * (our default construct path) makes `applySettings` attempt to resolve
+ * the wrapper before it is registered, causing a `TypeError`.
+ *
+ * The fix detects a forwarded default aggregation via
+ * `metadata.getAggregation(name)?.forwarding` and defers concrete children
+ * to a post-construction `addAggregation` call, matching how XMLView fills
+ * such aggregations.
+ *
+ * These tests deliberately create `Menu` instances **without** an explicit
+ * `id` so the broken code path is exercised (an explicit id was the
+ * reporter's workaround that masked the bug).
+ */
+import { jsx } from "ui5/community/jsx/runtime/jsx-runtime";
+import Menu from "sap/m/Menu";
+import MenuItem from "sap/m/MenuItem";
+
+QUnit.module("runtime/forwarded-aggregation");
+
+QUnit.test("Menu with multiple children (no id) — items populated correctly", (assert) => {
+	const menu = jsx(Menu, {
+		children: [
+			jsx(MenuItem, { text: "One" }),
+			jsx(MenuItem, { text: "Two" }),
+		]
+	}) as Menu;
+
+	const items = menu.getItems();
+	assert.strictEqual(items.length, 2, "two items forwarded into the Menu");
+	assert.strictEqual((items[0] as MenuItem).getText(), "One", "first item text correct");
+	assert.strictEqual((items[1] as MenuItem).getText(), "Two", "second item text correct");
+	menu.destroy();
+});
+
+QUnit.test("Menu with a single child (no id) — item populated correctly", (assert) => {
+	const menu = jsx(Menu, {
+		children: jsx(MenuItem, { text: "Only" }),
+	}) as Menu;
+
+	const items = menu.getItems();
+	assert.strictEqual(items.length, 1, "one item forwarded into the Menu");
+	assert.strictEqual((items[0] as MenuItem).getText(), "Only", "item text correct");
+	menu.destroy();
+});

--- a/packages/jsx-runtime/test/qunit/runtime/view-error-logging.qunit.ts
+++ b/packages/jsx-runtime/test/qunit/runtime/view-error-logging.qunit.ts
@@ -1,0 +1,144 @@
+/**
+ * QUnit regression tests: JSX view-construction errors are written to the
+ * UI5 Log (not just propagated as a rejected Promise).
+ *
+ * `installViewScopeBridge` patches `View.prototype.createContent` so that
+ * any thrown error — whether synchronous or from an async `createContent`
+ * that returns a rejected Promise — is:
+ *   1. Logged via `Log.error` with a message that includes the view id and
+ *      the original error text.
+ *   2. Re-thrown / re-rejected, so callers (e.g. `View.create`) still
+ *      receive the rejection unchanged.
+ *
+ * The tests trigger the two error paths by registering tiny inline View
+ * modules and loading them via `View.create`. `Log.error` is swapped out
+ * for a recorder for the duration of each test. UI5's View lifecycle
+ * produces a secondary unhandled rejection after the first one propagates;
+ * we intercept it with a window-level `unhandledrejection` handler so
+ * QUnit doesn't count it as a test failure.
+ */
+import View from "sap/ui/core/mvc/View";
+import Log from "sap/base/Log";
+import { installViewScopeBridge } from "ui5/community/jsx/runtime/runtime/installViewScopeBridge";
+
+// Ensure the bridge patch is applied before the first test runs.
+installViewScopeBridge();
+
+/** Replace `Log.error` with a call recorder for one test. */
+function stubLogError(): {
+	calls: Array<[string, string, string]>;
+	restore: () => void;
+} {
+	const calls: Array<[string, string, string]> = [];
+	const original = Log.error.bind(Log);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(Log as any).error = (msg: string, detail: string, component: string) => {
+		calls.push([msg, detail, component]);
+	};
+	return {
+		calls,
+		restore() {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(Log as any).error = original;
+		}
+	};
+}
+
+/** Suppress unhandled rejections for the duration of a callback. */
+function withRejectionSuppression(fn: () => Promise<void>): Promise<void> {
+	const handler = (e: PromiseRejectionEvent) => e.preventDefault();
+	window.addEventListener("unhandledrejection", handler);
+	return fn().finally(() => window.removeEventListener("unhandledrejection", handler));
+}
+
+QUnit.module("runtime/view-error-logging");
+
+// ---------------------------------------------------------------------------
+// Sync-throw variant
+// ---------------------------------------------------------------------------
+
+QUnit.test("sync throw in createContent() — Log.error called once, rejection preserved", (assert) => {
+	const done = assert.async();
+	return withRejectionSuppression(async () => {
+		const stub = stubLogError();
+		let caught: unknown;
+		try {
+			sap.ui.define(
+				"test/view/ThrowingView",
+				["sap/ui/core/mvc/View"],
+				function (BaseView: typeof View) {
+					return BaseView.extend("test.view.ThrowingView", {
+						createContent() {
+							throw new TypeError("deliberate sync error");
+						}
+					});
+				}
+			);
+
+			try {
+				await View.create({ viewName: "module:test/view/ThrowingView" });
+			} catch (err) {
+				caught = err;
+			}
+
+			assert.ok(caught != null, "View.create rejected on createContent() failure");
+			assert.strictEqual(stub.calls.length, 1, "Log.error called exactly once");
+			if (stub.calls.length >= 1) {
+				const [msg, , component] = stub.calls[0];
+				assert.ok(
+					msg.includes("deliberate sync error"),
+					`log message contains original error text: "${msg}"`
+				);
+				assert.strictEqual(component, "ui5.community.jsx.runtime", "component id correct");
+			}
+		} finally {
+			stub.restore();
+			done();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Async-reject variant
+// ---------------------------------------------------------------------------
+
+QUnit.test("async rejected createContent() — Log.error called once, rejection preserved", (assert) => {
+	const done = assert.async();
+	return withRejectionSuppression(async () => {
+		const stub = stubLogError();
+		let caught: unknown;
+		try {
+			sap.ui.define(
+				"test/view/AsyncThrowingView",
+				["sap/ui/core/mvc/View"],
+				function (BaseView: typeof View) {
+					return BaseView.extend("test.view.AsyncThrowingView", {
+						createContent() {
+							return Promise.reject(new RangeError("deliberate async error"));
+						}
+					});
+				}
+			);
+
+			try {
+				await View.create({ viewName: "module:test/view/AsyncThrowingView" });
+			} catch (err) {
+				caught = err;
+			}
+
+			assert.ok(caught != null, "View.create rejected on async createContent() failure");
+			assert.strictEqual(stub.calls.length, 1, "Log.error called exactly once");
+			if (stub.calls.length >= 1) {
+				const [msg, , component] = stub.calls[0];
+				assert.ok(
+					msg.includes("deliberate async error"),
+					`log message contains original error text: "${msg}"`
+				);
+				assert.strictEqual(component, "ui5.community.jsx.runtime", "component id correct");
+			}
+		} finally {
+			stub.restore();
+			done();
+		}
+	});
+});

--- a/packages/jsx-runtime/test/qunit/testsuite.qunit.ts
+++ b/packages/jsx-runtime/test/qunit/testsuite.qunit.ts
@@ -34,6 +34,8 @@ export default {
 		"runtime/property-appliers": { title: "runtime: PropertyApplier ordering" },
 		"runtime/auto-prefix-id": { title: "runtime: auto id prefix bridge" },
 		"runtime/string-aggregation-binding": { title: "runtime: string aggregation binding + template" },
+		"runtime/forwarded-aggregation": { title: "runtime: forwarded default aggregation (Menu#items)" },
+		"runtime/view-error-logging": { title: "runtime: view createContent() errors logged via Log.error" },
 		"plugins/switch": { title: "plugins: <Switch> / <Case> / <Default>" }
 	}
 };


### PR DESCRIPTION
## Summary

- **`installViewScopeBridge.ts`**: patches `View.prototype.onControllerConnected` (instead of `createContent`, which subclass dynamic dispatch bypasses) to install a per-instance wrapper on `this.createContent`. The wrapper: opens the JSX scope (`withScope`), calls `Log.error` on any sync throw or async rejection, then re-throws/re-rejects so propagation is unchanged. The instance own-property is deleted in a `finally` block.
- **`ExploreSample.tsx`**: adds `Log.error` in both catch handlers (demo-view load failure and docs-load failure) so the exact user-facing message is traceable in the UI5 log.
- **QUnit tests** (`runtime/view-error-logging.qunit.ts`): two regression tests verify sync-throw and async-reject paths — `Log.error` called exactly once with the right message/component id, and `View.create` still rejects.
- Also brings `runtime/forwarded-aggregation.qunit.ts` from `fix/forwarded-aggregation-issue-9` (was missing on `main`; needed for the testsuite entry already added there).

## Why patch `onControllerConnected`, not `createContent`

UI5's `onControllerConnected` calls `this.createContent(e)`, which dynamically dispatches to the **subclass** prototype. Patching `View.prototype.createContent` only intercepts code that explicitly calls `super.createContent()` — no View subclass does that (the base method is a no-op). By patching `onControllerConnected` instead, we install a per-instance own-property that shadows both the subclass prototype and `View.prototype`, so every call path — including `runWithPreprocessors` — routes through our wrapper.

## Test plan

- [ ] `cd packages/jsx-runtime && npm test` — all 12 test modules green (47 total), including `runtime/view-error-logging 🧪 2/2`
- [ ] `tsc --noEmit` clean, `eslint` clean
- [ ] Changeset present: `.changeset/log-view-errors.md` (patch bump for `@ui5-community/jsx-runtime`)